### PR TITLE
fix(webhook): HTTP headers are not required

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -58,7 +58,6 @@
     }
   },"required": [
       "url",
-      "method",
-      "headers"
+      "method"
   ]
 }


### PR DESCRIPTION
Closes gravitee-io/issues#3972