### PR TITLE
fix(webhook): Do not verify SNI during SSL handshake

### DIFF
--- a/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
+++ b/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
@@ -78,7 +78,9 @@ public class WebhookNotifier extends AbstractConfigurableNotifier<WebhookNotifie
         HttpClientOptions options = new HttpClientOptions();
 
         if (HTTPS_SCHEME.equalsIgnoreCase(target.getScheme())) {
-            options.setSsl(true).setTrustAll(true);
+            options.setSsl(true)
+                    .setTrustAll(true)
+                    .setVerifyHost(false);
         }
 
         options.setMaxPoolSize(1)


### PR DESCRIPTION
Closes gravitee-io/issues#4355