### PR TITLE
fix: keep the query params when the webhook is called

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,14 @@
         <gravitee-node-api.version>1.6.6</gravitee-node-api.version>
         <gravitee-notifier-api.version>1.2.1</gravitee-notifier-api.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-surfire-plugin.version>2.22.2</maven-surfire-plugin.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <powermock.version>2.0.0</powermock.version>
+        <vertx-junit5.version>4.4.4</vertx-junit5.version>
+        <wiremock.version>2.27.2</wiremock.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>plugins/notifiers</publish-folder-path>
     </properties>
@@ -57,6 +60,14 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.9.3</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -95,6 +106,24 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <version>${vertx-junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -180,6 +209,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surfire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
+++ b/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
@@ -112,7 +112,7 @@ public class WebhookNotifier extends AbstractConfigurableNotifier<WebhookNotifie
         HttpClient client = Vertx.currentContext().owner().createHttpClient(options);
 
         RequestOptions requestOpts = new RequestOptions()
-            .setURI(target.getPath())
+            .setURI(target.getPath() + (target.getQuery() != null ? "?" + target.getQuery() : ""))
             .setMethod(convert(configuration.getMethod()))
             .setFollowRedirects(true)
             .setTimeout(httpClientTimeout);

--- a/src/main/java/io/gravitee/notifier/webhook/configuration/HttpHeader.java
+++ b/src/main/java/io/gravitee/notifier/webhook/configuration/HttpHeader.java
@@ -27,6 +27,11 @@ public class HttpHeader {
 
     private String value;
 
+    public HttpHeader(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/test/java/io/gravitee/notifier/webhook/AbstractWebhookNotifier.java
+++ b/src/test/java/io/gravitee/notifier/webhook/AbstractWebhookNotifier.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.notifier.webhook;
+
+import io.vertx.junit5.VertxTestContext;
+import java.util.function.BiFunction;
+
+/**
+ * @author Aurelien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AbstractWebhookNotifier {
+
+    protected static BiFunction<Void, Throwable, Object> success(VertxTestContext testContext) {
+        return (unused, throwable) -> {
+            if (throwable != null) {
+                testContext.failNow(throwable);
+            } else {
+                testContext.completeNow();
+            }
+
+            return null;
+        };
+    }
+
+    protected static String buildHttpWebhookURL(int port, String path) {
+        return buildHttpWebhookURL("http", port, path);
+    }
+
+    protected static String buildHttpsWebhookURL(int port, String path) {
+        return buildHttpWebhookURL("https", port, path);
+    }
+
+    private static String buildHttpWebhookURL(String scheme, int port, String path) {
+        return scheme + "://127.0.0.1:" + port + "/" + path;
+    }
+}

--- a/src/test/java/io/gravitee/notifier/webhook/HttpWebhookNotifierTest.java
+++ b/src/test/java/io/gravitee/notifier/webhook/HttpWebhookNotifierTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.notifier.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.notifier.api.Notification;
+import io.gravitee.notifier.webhook.configuration.HttpHeader;
+import io.gravitee.notifier.webhook.configuration.WebhookNotifierConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * @author Aurelien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(VertxExtension.class)
+public class HttpWebhookNotifierTest extends AbstractWebhookNotifier {
+
+    @RegisterExtension
+    private static final RunTestOnContext runTestOnContext = new RunTestOnContext();
+
+    private Vertx vertx;
+
+    private static final WireMockServer wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+
+    @BeforeAll
+    static void beforeAll() {
+        wireMockServer.start();
+    }
+
+    @BeforeEach
+    void prepare(VertxTestContext testContext) {
+        vertx = runTestOnContext.vertx();
+        testContext.completeNow();
+    }
+
+    @AfterEach
+    void cleanUp(VertxTestContext testContext) {
+        wireMockServer.resetMappings();
+        testContext.completeNow();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    public void webhookUrlWithoutQueryParam(VertxTestContext testContext) {
+        wireMockServer.stubFor(post(urlPathEqualTo("/withoutQueryParam")).willReturn(ok()));
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), "withoutQueryParam"));
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+
+    @Test
+    public void webhookUrlWithQueryParam(VertxTestContext testContext) {
+        wireMockServer.stubFor(
+            post(urlPathEqualTo("/withQueryParam"))
+                .withQueryParam("param1", equalTo("param1"))
+                .withQueryParam("param2", equalTo("param2"))
+                .willReturn(ok())
+        );
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), "withQueryParam?param1=param1&param2=param2"));
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+
+    @Test
+    public void webhookWithHeader(VertxTestContext testContext) {
+        wireMockServer.stubFor(
+            post(urlPathEqualTo("/header"))
+                .withHeader("header1", equalTo("value1"))
+                .withHeader("header2", equalTo("value2"))
+                .willReturn(ok())
+        );
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), "header"));
+        webhookNotifierConfiguration.setHeaders(List.of(new HttpHeader("header1", "value1"), new HttpHeader("header2", "value2")));
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+
+    @Test
+    public void webhookWithBody(VertxTestContext testContext) {
+        wireMockServer.stubFor(post(urlPathEqualTo("/body")).withRequestBody(equalToJson("{ \"name\":\"value\" }")).willReturn(ok()));
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), "body"));
+        webhookNotifierConfiguration.setBody("{ \"name\":\"value\" }");
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+
+    @Test
+    public void webhookUrlNotReachable(VertxTestContext testContext) {
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), "notReachable"));
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration)
+            .doSend(new Notification(), Map.of())
+            .handle((unused, throwable) -> {
+                if (throwable != null) {
+                    testContext.completeNow();
+                } else {
+                    testContext.failNow(new IllegalStateException("URL reachable"));
+                }
+
+                return null;
+            });
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names = "CONNECT", mode = EnumSource.Mode.EXCLUDE)
+    public void webhookWithSpecificHttpMethod(HttpMethod method, VertxTestContext testContext) {
+        wireMockServer.stubFor(request(method.name(), urlPathEqualTo("/" + method.name())).willReturn(ok()));
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpWebhookURL(wireMockServer.port(), method.name()));
+        webhookNotifierConfiguration.setMethod(method);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+}

--- a/src/test/java/io/gravitee/notifier/webhook/HttpsWebhookNotifierTest.java
+++ b/src/test/java/io/gravitee/notifier/webhook/HttpsWebhookNotifierTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.notifier.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.notifier.api.Notification;
+import io.gravitee.notifier.webhook.configuration.WebhookNotifierConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.Map;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * @author Aurelien PACAUD (aurelien.pacaud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(VertxExtension.class)
+public class HttpsWebhookNotifierTest extends AbstractWebhookNotifier {
+
+    @RegisterExtension
+    private static final RunTestOnContext runTestOnContext = new RunTestOnContext();
+
+    private Vertx vertx;
+
+    private static final WireMockServer wireMockServer = new WireMockServer(wireMockConfig().dynamicHttpsPort().httpDisabled(true));
+
+    @BeforeAll
+    static void beforeAll() {
+        wireMockServer.start();
+    }
+
+    @BeforeEach
+    void prepare(VertxTestContext testContext) {
+        vertx = runTestOnContext.vertx();
+        testContext.completeNow();
+    }
+
+    @AfterEach
+    void cleanUp(VertxTestContext testContext) {
+        wireMockServer.resetMappings();
+        testContext.completeNow();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    public void webhookHttpsUrl(VertxTestContext testContext) {
+        wireMockServer.stubFor(post(urlPathEqualTo("/webhook")).willReturn(ok()));
+
+        WebhookNotifierConfiguration webhookNotifierConfiguration = new WebhookNotifierConfiguration();
+        webhookNotifierConfiguration.setUrl(buildHttpsWebhookURL(wireMockServer.httpsPort(), "webhook"));
+        webhookNotifierConfiguration.setMethod(HttpMethod.POST);
+
+        new WebhookNotifier(webhookNotifierConfiguration).doSend(new Notification(), Map.of()).handle(success(testContext));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AE-67

**Description**

If the URL of the webhook contains query params, these query params are kept and sent 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-ae-67-keep-query-params-webhook-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-webhook/1.1.1-ae-67-keep-query-params-webhook-SNAPSHOT/gravitee-notifier-webhook-1.1.1-ae-67-keep-query-params-webhook-SNAPSHOT.zip)
  <!-- Version placeholder end -->
