### PR TITLE
fix: http headers with default constructor for serialization

### DIFF
--- a/src/main/java/io/gravitee/notifier/webhook/configuration/HttpHeader.java
+++ b/src/main/java/io/gravitee/notifier/webhook/configuration/HttpHeader.java
@@ -27,6 +27,9 @@ public class HttpHeader {
 
     private String value;
 
+    //Do not remove. Useful for serialization
+    public HttpHeader() {}
+
     public HttpHeader(String name, String value) {
         this.name = name;
         this.value = value;


### PR DESCRIPTION
This PR leaves the default constructor for HttpHeaders to use it for serialization.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.2-fix-http-header-constructor-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-webhook/1.1.2-fix-http-header-constructor-SNAPSHOT/gravitee-notifier-webhook-1.1.2-fix-http-header-constructor-SNAPSHOT.zip)
  <!-- Version placeholder end -->
