### PR TITLE
fix: accept 2xx status instead of only 200

### DIFF
--- a/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
+++ b/src/main/java/io/gravitee/notifier/webhook/WebhookNotifier.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.notifier.webhook;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.notifier.api.AbstractConfigurableNotifier;
 import io.gravitee.notifier.api.Notification;
 import io.gravitee.notifier.api.exception.NotifierException;
@@ -150,7 +149,7 @@ public class WebhookNotifier extends AbstractConfigurableNotifier<WebhookNotifie
     }
 
     private void handleSuccess(CompletableFuture<Void> future, HttpClient client, HttpClientResponse httpResponse) {
-        if (httpResponse.statusCode() == HttpStatusCode.OK_200) {
+        if (isStatus2xx(httpResponse)) {
             httpResponse.bodyHandler(buffer -> {
                 logger.info("Webhook sent!");
                 future.complete(null);
@@ -180,6 +179,10 @@ public class WebhookNotifier extends AbstractConfigurableNotifier<WebhookNotifie
             // Close client
             client.close();
         }
+    }
+
+    private static boolean isStatus2xx(HttpClientResponse httpResponse) {
+        return httpResponse.statusCode() / 100 == 2;
     }
 
     private void handleFailure(CompletableFuture<Void> future, HttpClient client, Throwable throwable) {

--- a/src/test/java/io/gravitee/notifier/webhook/AbstractWebhookNotifier.java
+++ b/src/test/java/io/gravitee/notifier/webhook/AbstractWebhookNotifier.java
@@ -36,6 +36,18 @@ public class AbstractWebhookNotifier {
         };
     }
 
+    protected static BiFunction<Void, Throwable, Object> error(VertxTestContext testContext) {
+        return (unused, throwable) -> {
+            if (throwable != null) {
+                testContext.completeNow();
+            } else {
+                testContext.failNow(new IllegalStateException("An error was expected but none has been thrown"));
+            }
+
+            return null;
+        };
+    }
+
     protected static String buildHttpWebhookURL(int port, String path) {
         return buildHttpWebhookURL("http", port, path);
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1992
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.3-apim-1992-webhook-success-2xx-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-webhook/1.1.3-apim-1992-webhook-success-2xx-SNAPSHOT/gravitee-notifier-webhook-1.1.3-apim-1992-webhook-success-2xx-SNAPSHOT.zip)
  <!-- Version placeholder end -->
